### PR TITLE
Exp token sequence classification

### DIFF
--- a/classification/config.yaml.template
+++ b/classification/config.yaml.template
@@ -10,7 +10,7 @@ dataset: dataset 종류 (str) ["APEACH", "BEEP!", "Unsmile", "k-mhas", "KOLD", "
 train_dir: 훈련셋 csv 경로(str)
 valid_dir: 평가셋 csv 경로(str)
 
-model: 모델 유형 ["CNN", "VerifiableCNN", "Transformer", "SpanTransformer"]
+model: 모델 유형 ["CNN", "VerifiableCNN", "Transformer", "SpanTransformer", "TokenSequenceTransformer"]
 ## TODO: 아래 2개 항목은 삭제될 예정.
 # model type이 'CNN'일 때만 사용됨.
 get_bert_embedding: True

--- a/classification/config.yaml.template
+++ b/classification/config.yaml.template
@@ -11,10 +11,6 @@ train_dir: 훈련셋 csv 경로(str)
 valid_dir: 평가셋 csv 경로(str)
 
 model: 모델 유형 ["CNN", "VerifiableCNN", "Transformer", "SpanTransformer", "TokenSequenceTransformer"]
-## TODO: 아래 2개 항목은 삭제될 예정.
-# model type이 'CNN'일 때만 사용됨.
-get_bert_embedding: True
-embedding: pretrain된 임베딩 레이어 저장 경로(.pt)
 
 batch_size: (int)
 epochs: (int)

--- a/classification/data/__init__.py
+++ b/classification/data/__init__.py
@@ -1,3 +1,3 @@
 from .dataset import Apeach_Dataset, kmhas_Dataset, KOLD_Dataset, Beep_Dataset, Unsmile_Dataset
 from .tokenization_kocharelectra import KoCharElectraTokenizer
-from .span_dataset import Span_Dataset
+from .span_dataset import Span_Dataset, Sequence_Span_Dataset

--- a/classification/inference_config.yaml.template
+++ b/classification/inference_config.yaml.template
@@ -7,4 +7,3 @@ result_dir: 결과 csv 저장할 경로(.csv)
 batch_size: int
 dataset: ["APEACH", "BEEP!", "Unsmile", "k-mhas", "KOLD", "KOLD_SPAN"]
 model: ["CNN", "VerifiableCNN", "Transformer", "SpanTransformer"]
-get_bert_embedding: False # 고정값.

--- a/classification/model/__init__.py
+++ b/classification/model/__init__.py
@@ -1,2 +1,2 @@
-from .bert_model import transformer, span_transformer
+from .bert_model import transformer, span_transformer, Token_Sequence_transformer
 from .cnn_model import CNNModel, VerifiableCNN

--- a/classification/model/bert_model.py
+++ b/classification/model/bert_model.py
@@ -18,9 +18,8 @@ class Token_Sequence_transformer(nn.Module):
     def __init__(self, config, vocab_size=None):
         super(Token_Sequence_transformer, self).__init__()
         self.transformer = AutoModel.from_pretrained(config["model_name"])
-        self.sequence_classification = nn.Linear(256, 1)
+        self.sequence_classification = nn.Linear(256, 9)
         self.token_classification = nn.Linear(256, 2)
-        self.sigmoid = nn.Sigmoid()
         
     def forward(self, input_ids, attention_mask, token_type_ids):
         hidden_states = self.transformer(input_ids, attention_mask, token_type_ids).last_hidden_state
@@ -29,7 +28,6 @@ class Token_Sequence_transformer(nn.Module):
         
         cls_output = hidden_states[:, 0, :]
         sequence_output = self.sequence_classification(cls_output)
-        sequence_output = self.sigmoid(sequence_output)
         
         return token_output, sequence_output
     

--- a/classification/model/bert_model.py
+++ b/classification/model/bert_model.py
@@ -20,6 +20,7 @@ class Token_Sequence_transformer(nn.Module):
         self.transformer = AutoModel.from_pretrained(config["model_name"])
         self.sequence_classification = nn.Linear(256, 1)
         self.token_classification = nn.Linear(256, 2)
+        self.sigmoid = nn.Sigmoid()
         
     def forward(self, input_ids, attention_mask, token_type_ids):
         hidden_states = self.transformer(input_ids, attention_mask, token_type_ids).last_hidden_state
@@ -28,6 +29,7 @@ class Token_Sequence_transformer(nn.Module):
         
         cls_output = hidden_states[:, 0, :]
         sequence_output = self.sequence_classification(cls_output)
+        sequence_output = self.sigmoid(sequence_output)
         
         return token_output, sequence_output
     

--- a/classification/model/bert_model.py
+++ b/classification/model/bert_model.py
@@ -15,7 +15,7 @@ def span_transformer(config, vocab_size=None):
     )
     
 class Token_Sequence_transformer(nn.Module):
-    def __init__(self, config):
+    def __init__(self, config, vocab_size=None):
         super(Token_Sequence_transformer, self).__init__()
         self.transformer = AutoModel.from_pretrained(config["model_name"])
         self.sequence_classification = nn.Linear(256, 1)

--- a/classification/model/bert_model.py
+++ b/classification/model/bert_model.py
@@ -1,4 +1,5 @@
-from transformers import AutoModelForSequenceClassification, AutoModelForTokenClassification
+from transformers import AutoModelForSequenceClassification, AutoModelForTokenClassification, AutoModel
+import torch.nn as nn
 
     
 def transformer(config, vocab_size=None):
@@ -12,4 +13,21 @@ def span_transformer(config, vocab_size=None):
         config["model_name"],
         num_labels=2
     )
+    
+class Token_Sequence_transformer(nn.Module):
+    def __init__(self, config):
+        super(Token_Sequence_transformer, self).__init__()
+        self.transformer = AutoModel.from_pretrained(config["model_name"])
+        self.sequence_classification = nn.Linear(256, 1)
+        self.token_classification = nn.Linear(256, 2)
+        
+    def forward(self, input_ids, attention_mask, token_type_ids):
+        hidden_states = self.transformer(input_ids, attention_mask, token_type_ids).last_hidden_state
+        
+        token_output = self.token_classification(hidden_states)
+        
+        cls_output = hidden_states[:, 0, :]
+        sequence_output = self.sequence_classification(cls_output)
+        
+        return token_output, sequence_output
     

--- a/classification/model/cnn_model.py
+++ b/classification/model/cnn_model.py
@@ -9,9 +9,6 @@ class CNNModel(nn.Module):
         self.config = config
         
         self.Embedding = nn.Embedding(vocab_size, 768)
-        if self.config["get_bert_embedding"]:
-            embedding_weights = self.prepare_embeddings()
-            self.Embedding.weight = embedding_weights
         self.Layer = nn.Sequential(
             self.conv_block(128, 64), #384
             self.conv_block(64, 32), # 192
@@ -19,14 +16,6 @@ class CNNModel(nn.Module):
             nn.Linear(96, 1),
             nn.Sigmoid()
         )
-        
-    def prepare_embeddings(self):
-        transformer = AutoModel.from_pretrained(self.config["model_name"])
-        for name, param in transformer.named_parameters():
-            if "embeddings.word_embeddings" in name:
-                embedding_weights = param
-        del transformer
-        return embedding_weights
         
     def conv_block(self, in_channel, out_channel):
         return nn.Sequential(
@@ -47,9 +36,6 @@ class VerifiableCNN(nn.Module):
         self.config = config
         
         self.Embedding = nn.Embedding(vocab_size, 768)
-        if self.config["get_bert_embedding"]:
-            embedding_weights = self.prepare_embeddings()
-            self.Embedding.weight = embedding_weights
         self.Layer = nn.Sequential(
             nn.Conv1d(768, 128, kernel_size=3, padding=1),
             nn.ReLU(),
@@ -59,14 +45,6 @@ class VerifiableCNN(nn.Module):
             nn.Dropout(0.2),
         )
         self.sigmoid = nn.Sigmoid()
-        
-    def prepare_embeddings(self):
-        transformer = AutoModel.from_pretrained(self.config["model_name"])
-        for name, param in transformer.named_parameters():
-            if "embeddings.word_embeddings" in name:
-                embedding_weights = param
-        del transformer
-        return embedding_weights
     
     def mean_pooling(self, token_embeddings, attention_mask):
         input_mask_expanded = attention_mask.expand(token_embeddings.size()).float()

--- a/classification/train.py
+++ b/classification/train.py
@@ -4,16 +4,16 @@ import random
 import argparse
 
 from data import Apeach_Dataset, kmhas_Dataset, KOLD_Dataset, Beep_Dataset, Unsmile_Dataset, Span_Dataset
-from model import CNNModel, VerifiableCNN, transformer, span_transformer
-from trainer import HuggingfaceTrainer, CNNTrainer
+from model import CNNModel, VerifiableCNN, transformer, span_transformer, Token_Sequence_transformer
+from trainer import HuggingfaceTrainer, CNNTrainer, TokenSequenceTrainer
 
 
 Dataset = {"APEACH": Apeach_Dataset, "BEEP!": Beep_Dataset, "Unsmile": Unsmile_Dataset, 
            "k-mhas": kmhas_Dataset, "KOLD": KOLD_Dataset, "KOLD_SPAN": Span_Dataset}
 models = {"CNN": CNNModel, "VerifiableCNN": VerifiableCNN, "Transformer": transformer, 
-          "SpanTransformer": span_transformer}
+          "SpanTransformer": span_transformer, "TokenSequenceTransformer": Token_Sequence_transformer}
 trainers = {"CNN": CNNTrainer, "VerifiableCNN": CNNTrainer, "Transformer": HuggingfaceTrainer, 
-            "SpanTransformer": HuggingfaceTrainer}
+            "SpanTransformer": HuggingfaceTrainer, "TokenSequenceTransformer": TokenSequenceTrainer}
 
 
 def set_seed(random_seed):

--- a/classification/train.py
+++ b/classification/train.py
@@ -3,13 +3,13 @@ import torch
 import random
 import argparse
 
-from data import Apeach_Dataset, kmhas_Dataset, KOLD_Dataset, Beep_Dataset, Unsmile_Dataset, Span_Dataset
-from model import CNNModel, VerifiableCNN, transformer, span_transformer, Token_Sequence_transformer
-from trainer import HuggingfaceTrainer, CNNTrainer, TokenSequenceTrainer
+from data import *
+from model import *
+from trainer import *
 
 
 Dataset = {"APEACH": Apeach_Dataset, "BEEP!": Beep_Dataset, "Unsmile": Unsmile_Dataset, 
-           "k-mhas": kmhas_Dataset, "KOLD": KOLD_Dataset, "KOLD_SPAN": Span_Dataset}
+           "k-mhas": kmhas_Dataset, "KOLD": KOLD_Dataset, "KOLD_SPAN": Span_Dataset, "KOLD_Sequence_SPAN": Sequence_Span_Dataset}
 models = {"CNN": CNNModel, "VerifiableCNN": VerifiableCNN, "Transformer": transformer, 
           "SpanTransformer": span_transformer, "TokenSequenceTransformer": Token_Sequence_transformer}
 trainers = {"CNN": CNNTrainer, "VerifiableCNN": CNNTrainer, "Transformer": HuggingfaceTrainer, 

--- a/classification/trainer/__init__.py
+++ b/classification/trainer/__init__.py
@@ -1,2 +1,3 @@
 from .transformer_trainer import HuggingfaceTrainer
 from .cnn_trainer import CNNTrainer
+from .torch_trainer import TokenSequenceTrainer

--- a/classification/trainer/torch_trainer.py
+++ b/classification/trainer/torch_trainer.py
@@ -47,7 +47,7 @@ class TokenSequenceTrainer:
             self.model.train()
             for data in self.train_loader:
                 data = {k: v.to('cuda') for k, v in data.items()}
-                seq_label = data.pop('class_label')
+                seq_label = data.pop('class_labels')
                 token_label = data.pop('labels')
                 
                 token_output, seq_output = self.model(**data)
@@ -69,7 +69,7 @@ class TokenSequenceTrainer:
             self.model.eval()
             for data in self.valid_loader:
                 data = {k: v.to('cuda') for k, v in data.items()}
-                seq_label = data.pop('class_label')
+                seq_label = data.pop('class_labels')
                 token_label = data.pop('labels')
                 with torch.no_grad():
                     token_output, seq_output = self.model(**data)

--- a/classification/trainer/torch_trainer.py
+++ b/classification/trainer/torch_trainer.py
@@ -9,8 +9,8 @@ from tqdm import tqdm
 import wandb
 import os
 
-## TODO: CNN Trainer도 huggingface trainer로 합치기.
-class CNNTrainer:
+
+class TokenSequenceTrainer:
     def __init__(self, config, model, train_dataset, valid_dataset) -> None:
         self.config = config
         self.model = model

--- a/classification/trainer/torch_trainer.py
+++ b/classification/trainer/torch_trainer.py
@@ -100,7 +100,7 @@ def compute_multi_label_f1(preds, labels):
     rpreds = []
     for pred in preds:
         rpreds.append([1 if output > 0.5 else 0 for output in pred])
-    f1 = f1_score(labels, preds, average="macro")
+    f1 = f1_score(labels, rpreds, average="macro")
     return f1
         
 def compute_token_metrics(predictions, labels):

--- a/classification/trainer/torch_trainer.py
+++ b/classification/trainer/torch_trainer.py
@@ -1,0 +1,127 @@
+from transformers import DataCollatorForTokenClassification, get_linear_schedule_with_warmup
+from torch.utils.data import DataLoader
+from torch.optim import AdamW
+import torch.nn as nn
+import torch
+from sklearn.metrics import f1_score
+
+from tqdm import tqdm
+import wandb
+import os
+
+## TODO: CNN Trainer도 huggingface trainer로 합치기.
+class CNNTrainer:
+    def __init__(self, config, model, train_dataset, valid_dataset) -> None:
+        self.config = config
+        self.model = model
+        self.valid_dataset = valid_dataset
+        data_collator = DataCollatorForTokenClassification(tokenizer=train_dataset.tokenizer)
+        self.train_loader = DataLoader(train_dataset, config["batch_size"], shuffle=True, collate_fn=data_collator)
+        self.valid_loader = DataLoader(valid_dataset, config["batch_size"], collate_fn=data_collator)
+        
+        self.seq_criterion = nn.BCELoss()
+        self.token_criterion = nn.CrossEntropyLoss(ignore_index=-100)
+        
+        self.optimizer = AdamW(self.model.parameters(), lr=config["lr"])
+        
+        t_total = self.config["epochs"]*len(self.train_loader)
+        self.scheduler = get_linear_schedule_with_warmup(
+            self.optimizer,
+            num_warmup_steps=int(self.config["warmup_ratio"]*t_total),
+            num_training_steps=t_total
+        )
+        
+        self.best_model = None
+        self.best_loss = 100
+    
+    def train(self):
+        wandb.init(
+            project=self.config["wandb_project"], 
+            entity=self.config["wandb_entity"], 
+            name=self.config["wandb_name"],
+            group=self.config["wandb_group"],
+            config=self.config
+        )
+        
+        for epoch in tqdm(range(self.config["epochs"])):
+            self.model.train()
+            for data in self.train_loader:
+                data = {k: v.to('cuda') for k, v in data.items()}
+                seq_label = data.pop('class_label')
+                token_label = data.pop('labels')
+                
+                token_output, seq_output = self.model(**data)
+                
+                token_loss = self.token_criterion(token_output.transpose(1, 2), token_label)
+                seq_loss = self.seq_criterion(seq_output.squeeze(), seq_label.float())
+                total_loss = token_loss + seq_loss
+                
+                wandb.log({"token loss": token_loss, "sequence loss": seq_loss, "epochs": epoch})
+                total_loss.backward()
+                self.optimizer.step()
+                self.scheduler.step()
+                self.model.zero_grad()
+                
+            valid_loss = 0
+            seq_preds = []
+            token_preds = []
+            
+            self.model.eval()
+            for data in self.valid_loader:
+                data = {k: v.to('cuda') for k, v in data.items()}
+                seq_label = data.pop('class_label').float()
+                token_label = data.pop('labels')
+                with torch.no_grad():
+                    token_output, seq_output = self.model(**data)
+                token_loss = self.token_criterion(token_output.transpose(1, 2), token_label)
+                seq_loss = self.seq_criterion(seq_output.squeeze(), seq_label.float())
+                valid_loss += token_loss + seq_loss
+                
+                seq_preds += [1 if output.item() > 0.5 else 0 for output in seq_output.cpu()]
+                token_preds.append(torch.argmax(token_output, dim=-1).cpu())
+            
+            token_preds = torch.cat(token_preds, dim=0)
+            f1 = f1_score(seq_preds, self.valid_dataset.class_labels)
+            metric = compute_metrics(token_preds, self.valid_dataset.labels)
+            metric["f1 score"] = f1
+            metric["valid loss"] = valid_loss/len(self.valid_loader)
+            wandb.log(metric)
+            
+            if metric["valid loss"] < self.best_loss:
+                self.best_loss = metric["valid loss"]
+                self.best_model = self.model.state_dict().copy()
+
+        best_model_path = os.path.join(self.config["checkpoint_dir"], "pytorch_model.bin")
+        torch.save(self.best_model, best_model_path)
+        
+def compute_metrics(predictions, labels):
+    true_predictions = [
+        [p.item() for (p, l) in zip(prediction, label) if l != -100]
+        for prediction, label in zip(predictions, labels)
+    ]
+    true_labels = [
+        [l for (p, l) in zip(prediction, label) if l != -100]
+        for prediction, label in zip(predictions, labels)
+    ]
+
+    n_cnt = 0
+    p_cnt = 0
+
+    n_cor = 0
+    p_cor = 0
+
+    for pred, label in zip(true_predictions, true_labels):
+        for p, l in zip(pred, label):
+            if l == 0:
+                p_cnt += 1
+                if p == l:
+                    p_cor += 1
+            else:
+                n_cnt += 1
+                if p == l:
+                    n_cor += 1
+    return {
+        "Token Accuracy": (n_cor+p_cor)/(n_cnt+p_cnt),
+        "hate token accuracy": n_cor/n_cnt,
+        "none hate token accuracy": p_cor/p_cnt
+    }


### PR DESCRIPTION
## Classification
Sequence classification과 Token classification을 같이 수행하는 모델 코드를 구현.

### 데이터셋
Span_Dataset 수정 및 Sequence_Span_Dataset 추가.
Sequence_Span_Dataset 클래스는 아래 column들을 포함한 csv파일들을 전처리하여 multi-class label과 token label을 리턴한다.
>>>
    [comment,individual,untargeted,others,gender,race,politics,other,religion,sexual_orientation,start_index,end_index]

### 모델
model/bert_model에 Token_Sequence_transformer 추가.
본 모델은 Multi-Label Classification과 Token Classification을 같이 수행하는 모델.

### 트레이너
torch_trainer.py를 추가하여 Multi-task Learning을 수행하는 코드를 작성.

추가사항)
CNN모델에서 prepare_embedding 제거 : CNN Layer에 BERT Embedding을 사용하는 것은 원활한 학습을 방해함. 추가한다면 word2vec을 추가하는 것이 더 적절.

TODO)
KcELECTRA small 모델을 사용하게 됐으니 아마 CNN모델은 삭제해도 될 것 같습니다.